### PR TITLE
Fix to use decoding on CPU

### DIFF
--- a/music2latent/inference.py
+++ b/music2latent/inference.py
@@ -74,7 +74,7 @@ def decode_to_representation(model, latents, diffusion_steps=1):
     num_samples = latents.shape[0]
     downscaling_factor = 2**freq_downsample_list.count(0)
     sample_length = int(latents.shape[-1]*downscaling_factor)
-    initial_noise = torch.randn((num_samples, data_channels, hop*2, sample_length)).cuda()*sigma_max
+    initial_noise = torch.randn((num_samples, data_channels, hop*2, sample_length))*sigma_max
     decoded_spectrograms = reverse_diffusion(model, initial_noise, diffusion_steps, latents=latents)
     return decoded_spectrograms
 

--- a/music2latent/inference.py
+++ b/music2latent/inference.py
@@ -70,11 +70,11 @@ class EncoderDecoder:
 #   diffusion_steps: number of steps
 # Returns:
 #   decoded_spectrograms with shape [audio_channels/batch_size, data_channels, hop*2, length*downscaling_factor]
-def decode_to_representation(model, latents, diffusion_steps=1):
+def decode_to_representation(model, latents, diffusion_steps=1, device='cuda'):
     num_samples = latents.shape[0]
     downscaling_factor = 2**freq_downsample_list.count(0)
     sample_length = int(latents.shape[-1]*downscaling_factor)
-    initial_noise = torch.randn((num_samples, data_channels, hop*2, sample_length))*sigma_max
+    initial_noise = torch.randn((num_samples, data_channels, hop*2, sample_length)).to(device)*sigma_max
     decoded_spectrograms = reverse_diffusion(model, initial_noise, diffusion_steps, latents=latents)
     return decoded_spectrograms
 
@@ -196,11 +196,11 @@ def decode_latent_inference(latent, trainer, max_waveform_length_decode, max_bat
         latent_ls = torch.split(latent, max_batch_size, dim=0)
         repr_ls = []
         for i in range(len(latent_ls)):
-            repr = decode_to_representation(trainer.gen, latent_ls[i], diffusion_steps=diffusion_steps)
+            repr = decode_to_representation(trainer.gen, latent_ls[i], diffusion_steps=diffusion_steps, device=device)
             repr_ls.append(repr)
         repr = torch.cat(repr_ls, dim=0)
     else:
-        repr = decode_to_representation(trainer.gen, latent, diffusion_steps=diffusion_steps)
+        repr = decode_to_representation(trainer.gen, latent, diffusion_steps=diffusion_steps, device=device)
     # split samples
     if repr.shape[0]>1:
         repr_ls = torch.split(repr, audio_channels, 0)


### PR DESCRIPTION
I needed to make this small change to make inference on CPU possible.

Without it, I'm getting a CUDA error: 
```    
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In[5], line 1
----> 1 wv_rec = encdec.decode(latent)

File [...]/music2latent/inference.py:59, in EncoderDecoder.decode(self, latent, denoising_steps, max_waveform_length, max_batch_size)
     57 if max_batch_size is None: 
     58     max_batch_size = max_batch_size_decode
---> 59 return decode_latent_inference(latent, self, max_waveform_length, max_batch_size, diffusion_steps=denoising_steps, device=self.device)

File [...]/torch/utils/_contextlib.py:116, in context_decorator.<locals>.decorate_context(*args, **kwargs)
    113 @functools.wraps(func)
    114 def decorate_context(*args, **kwargs):
    115     with ctx_factory():
--> 116         return func(*args, **kwargs)

File [...]/music2latent/inference.py:203, in decode_latent_inference(latent, trainer, max_waveform_length_decode, max_batch_size_decode, diffusion_steps, device)
    201     repr = torch.cat(repr_ls, dim=0)
    202 else:
--> 203     repr = decode_to_representation(trainer.gen, latent, diffusion_steps=diffusion_steps)
    204 # split samples
    205 if repr.shape[0]>1:

File [...]/music2latent/inference.py:77, in decode_to_representation(model, latents, diffusion_steps)
     75 downscaling_factor = 2**freq_downsample_list.count(0)
     76 sample_length = int(latents.shape[-1]*downscaling_factor)
---> 77 initial_noise = torch.randn((num_samples, data_channels, hop*2, sample_length)).cuda()*sigma_max
     78 decoded_spectrograms = reverse_diffusion(model, initial_noise, diffusion_steps, latents=latents)
     79 return decoded_spectrograms

File [...]/site-packages/torch/cuda/__init__.py:305, in _lazy_init()
    300     raise RuntimeError(
    301         "Cannot re-initialize CUDA in forked subprocess. To use CUDA with "
    302         "multiprocessing, you must use the 'spawn' start method"
    303     )
    304 if not hasattr(torch._C, "_cuda_getDeviceCount"):
--> 305     raise AssertionError("Torch not compiled with CUDA enabled")
    306 if _cudart is None:
    307     raise AssertionError(
    308         "libcudart functions unavailable. It looks like you have a broken build?"
    309     )

AssertionError: Torch not compiled with CUDA enabled
```